### PR TITLE
Fix res

### DIFF
--- a/src/bench/framework_reserve.py
+++ b/src/bench/framework_reserve.py
@@ -66,16 +66,24 @@ class Reserve(object):
                 nodes=','.join(sorted(reserve_nodes_))
                 #print("RESERVATION NAME ", self.reservation_name)
                 #print("NODES = ", nodes)
-                bench.slurm.scontrol(
-                    subcommand=subcommand,
-                    reservation=self.reservation_name,
-                    accounts = 'admin',
-                    #accounts = self.account,
-                    flags='overlap',
-                    starttime='now',
-                    duration='UNLIMITED',
-                    nodes=','.join(sorted(reserve_nodes_)),
-                )
+
+                if subcommand == 'update':
+                    bench.slurm.scontrol(
+                        subcommand=subcommand,
+                        reservation=self.reservation_name,
+                        nodes=nodes,
+                    )
+                else:
+                    bench.slurm.scontrol(
+                        subcommand=subcommand,
+                        reservation=self.reservation_name,
+                        accounts = 'admin',
+                        #accounts = self.account,
+                        flags='overlap',
+                        starttime='now',
+                        duration='UNLIMITED',
+                        nodes=nodes,
+                    )
             except bench.exc.SlurmError as ex:
                 self.logger.error(ex)
                 self.logger.debug(ex, exc_info=True)

--- a/src/tests/test_fw_reserve.py
+++ b/src/tests/test_fw_reserve.py
@@ -134,6 +134,11 @@ class TestReserve(unittest.TestCase):
         self.assertEqual(kwargs_0['subcommand'], 'show')
         self.assertEqual(kwargs_1['subcommand'], 'update')
 
+        # Reservations already have a starttime/endtime. Updating with this will
+        # cause Slurm to error.
+        assert not ('endtime' in kwargs_1)
+        assert not ('starttime' in kwargs_1)
+
         for node in self.pass_nodes:
             self.assertNotIn(node, kwargs_1['nodes'])
         for node in self.fail_nodes:


### PR DESCRIPTION
Fixing the reserve when updating a reservation is needed instead of creating a new one.